### PR TITLE
feat: support custom database path via IMESSAGE_DB_PATH env var

### DIFF
--- a/packages/imessage/src/messages.ts
+++ b/packages/imessage/src/messages.ts
@@ -66,6 +66,8 @@ export const decodeAttributedBody = (
 };
 
 const getImessageDbPath = (): string => {
+  const envPath = Deno.env.get("IMESSAGE_DB_PATH");
+  if (envPath) return envPath;
   return join(homedir(), "Library", "Messages", "chat.db");
 };
 


### PR DESCRIPTION
## Summary

- Adds support for overriding the default `~/Library/Messages/chat.db` path via the `IMESSAGE_DB_PATH` environment variable
- When the env var is not set, behaviour is unchanged (fully backward compatible)

## Motivation

On macOS, reading `chat.db` directly requires granting Full Disk Access to the MCP server's parent process (e.g. Terminal or an IDE). By using a periodic `sqlite3 .backup` job to snapshot `chat.db` to a non-TCC-protected location (e.g. `/tmp`), the MCP server can read the snapshot without needing FDA — narrowing the security grant to just the copy job.

## Usage

```json
{
  "imessage": {
    "command": "deno",
    "args": ["run", "--allow-read", "--allow-env", "--allow-sys", "--allow-ffi", "--allow-net", "jsr:@wyattjoh/imessage-mcp"],
    "env": {
      "IMESSAGE_DB_PATH": "/tmp/imessage-snapshot.sqlite"
    }
  }
}
```

## Test plan

- [x] Verified MCP tools work correctly when `IMESSAGE_DB_PATH` points to a snapshot copy
- [x] Verified default behaviour is unchanged when env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)